### PR TITLE
ThreadUtils predicate visitor/collector pattern

### DIFF
--- a/src/main/java/org/apache/commons/lang3/util/function/Collector.java
+++ b/src/main/java/org/apache/commons/lang3/util/function/Collector.java
@@ -1,0 +1,66 @@
+package org.apache.commons.lang3.util.function;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Collect visited objects.
+ * @param <T> The type of collected objects.
+ */
+public class Collector<T> implements Predicate<T> {
+	final private List<T> collected;    	     	
+	final private Predicate<T> predicate;
+	final int maxToCollect;
+	
+	/**
+	 * Create an unlimited collector.
+	 * 
+	 * @param predicate The predicate that determines which objects are to be collected.
+	 */
+	public Collector(Predicate<T> predicate) {
+		this(predicate, Integer.MAX_VALUE);
+	}
+
+	/**
+	 * Create a limited size collector.
+	 *  
+	 * @param predicate The predicate that determines which objects are to be collected.
+	 * @param maxToCollect The maximum count of objects to collect.
+	 */
+	public Collector(Predicate<T> predicate, int maxToCollect) {
+		this.predicate = predicate;
+		this.maxToCollect = maxToCollect;
+		this.collected = maxToCollect!=Integer.MAX_VALUE ?new ArrayList<T>(maxToCollect) :new ArrayList<T>();
+	}    	
+
+	/**
+	 * Invoke predicate to determine if object should be collected.
+	 * 
+	 * @param t The object that could be collected.
+	 * @return true if collected count is less than maximum count.
+	 */
+	@Override
+    public boolean test(T t) {
+		if(predicate.test(t)) {
+			collected.add(t);
+		}
+		return collected.size()<maxToCollect;
+	}
+	
+	/**
+	 * Get the collected objects.
+	 * @return The objects which the predicate selected.
+	 */
+	public Collection<T> getResults() {
+		return collected;
+	}
+
+	/**
+	 * Get the first collected value.
+	 * @return The first value collected, or null.
+	 */
+	public T getFirst() {
+		return collected.size()>0 ?collected.get(0) :null;
+	}
+}

--- a/src/main/java/org/apache/commons/lang3/util/function/Predicate.java
+++ b/src/main/java/org/apache/commons/lang3/util/function/Predicate.java
@@ -1,0 +1,11 @@
+package org.apache.commons.lang3.util.function;
+
+
+/**
+ * Predicate compatible with Java8
+ */
+public interface Predicate<T> extends java.util.function.Predicate<T> {
+
+	@Override
+    boolean test(T t);
+}

--- a/src/main/java/org/apache/commons/lang3/util/function/Predicates.java
+++ b/src/main/java/org/apache/commons/lang3/util/function/Predicates.java
@@ -1,0 +1,16 @@
+package org.apache.commons.lang3.util.function;
+
+public class Predicates {
+	
+	public static final Predicate<? super Object> ALWAYS_TRUE = new Predicate<Object>() {;
+	    @Override
+	    public boolean test(final Object ignored) {
+	        return true;
+	    }
+	};
+
+	@SuppressWarnings("unchecked")
+	public static <T> Predicate<T> alwaysTrue() {
+		return (Predicate<T>) Predicates.ALWAYS_TRUE;
+	}
+}

--- a/src/test/java/org/apache/commons/lang3/ThreadUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/ThreadUtilsTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertTrue;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
@@ -42,68 +41,68 @@ import org.junit.Test;
  */
 public class ThreadUtilsTest {
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testNullThreadName() throws InterruptedException {
+    @Test(expected=NullPointerException.class)
+    public void testNullThreadName() {
         ThreadUtils.findThreadsByName(null);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testNullThreadGroupName() throws InterruptedException {
+    @Test(expected=NullPointerException.class)
+    public void testNullThreadGroupName() {
         ThreadUtils.findThreadGroupsByName(null);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testNullThreadThreadGroupName1() throws InterruptedException {
+    @Test(expected=NullPointerException.class)
+    public void testNullThreadThreadGroupName1() {
         ThreadUtils.findThreadsByName(null, "tgname");
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testNullThreadThreadGroupName2() throws InterruptedException {
+    @Test(expected=NullPointerException.class)
+    public void testNullThreadThreadGroupName2() {
         ThreadUtils.findThreadsByName("tname", (String) null);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testNullThreadThreadGroupName3() throws InterruptedException {
+    @Test(expected=NullPointerException.class)
+    public void testNullThreadThreadGroupName3() {
         ThreadUtils.findThreadsByName(null, (String) null);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testNullThreadThreadGroup1() throws InterruptedException {
+    @Test(expected=NullPointerException.class)
+    public void testNullThreadThreadGroup1() {
         ThreadUtils.findThreadsByName("tname", (ThreadGroup) null);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testNullThreadThreadGroup2() throws InterruptedException {
+    @Test(expected=NullPointerException.class)
+    public void testNullThreadThreadGroup2() {
         ThreadUtils.findThreadById(1L, (ThreadGroup) null);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testNullThreadThreadGroup3() throws InterruptedException {
+    @Test(expected=NullPointerException.class)
+    public void testNullThreadThreadGroup3() {
         ThreadUtils.findThreadsByName(null, (ThreadGroup) null);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void testInvalidThreadId() throws InterruptedException {
+    public void testInvalidThreadId() {
         ThreadUtils.findThreadById(-5L);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testThreadGroupsByIdFail() throws InterruptedException {
+    @Test(expected=NullPointerException.class)
+    public void testThreadGroupsByIdFail() {
         ThreadUtils.findThreadById(Thread.currentThread().getId(), (String) null);
     }
 
     @Test
-    public void testNoThread() throws InterruptedException {
+    public void testNoThread() {
         assertEquals(0, ThreadUtils.findThreadsByName("some_thread_which_does_not_exist_18762ZucTT").size());
     }
 
     @Test
-    public void testNoThreadGroup() throws InterruptedException {
+    public void testNoThreadGroup() {
         assertEquals(0, ThreadUtils.findThreadGroupsByName("some_thread_group_which_does_not_exist_18762ZucTTII").size());
     }
 
     @Test
-    public void testSystemThreadGroupExists() throws InterruptedException {
+    public void testSystemThreadGroupExists() {
         final ThreadGroup systemThreadGroup = ThreadUtils.getSystemThreadGroup();
         assertNotNull(systemThreadGroup);
         assertNull(systemThreadGroup.getParent());
@@ -111,13 +110,13 @@ public class ThreadUtilsTest {
     }
 
     @Test
-    public void testAtLeastOneThreadExists() throws InterruptedException {
+    public void testAtLeastOneThreadExists() {
         assertTrue(ThreadUtils.getAllThreads().size() > 0);
     }
 
     @Test
-    public void testAtLeastTwoThreadGroupsExists() throws InterruptedException {
-        assertTrue(ThreadUtils.getAllThreadGroups().size() > 1);
+    public void testAtLeastOneThreadGroupsExists() {
+        assertTrue(ThreadUtils.getAllThreadGroups().size() >= 1);
     }
 
     @Test
@@ -263,7 +262,7 @@ public class ThreadUtilsTest {
     }
 
     @Test
-    public void testConstructor() throws InterruptedException {
+    public void testConstructor() {
         assertNotNull(new ThreadUtils());
         final Constructor<?>[] cons = ThreadUtils.class.getDeclaredConstructors();
         assertEquals(1, cons.length);
@@ -295,60 +294,26 @@ public class ThreadUtilsTest {
         final List<Thread> threads = Arrays.asList(t1,t2,t3,t4,t5,t6,t7,t8,t9,t10);
 
         try {
-            for (final Iterator iterator = threads.iterator(); iterator.hasNext();) {
-                final Thread thread = (Thread) iterator.next();
+            for (final Thread thread : threads) {
                 thread.start();
             }
             //new ThreadUtils.ThreadGroupHolder(ThreadUtils.getSystemThreadGroup()).accept(new PrintVisitor());
 
-            assertTrue(ThreadUtils.getAllThreadGroups().size() >= 8);
+            assertTrue(ThreadUtils.getAllThreadGroups().size() >= 7);
             assertTrue(ThreadUtils.getAllThreads().size() >= 11);
            
         }finally {
-            for (final Iterator iterator = threads.iterator(); iterator.hasNext();) {
-                final Thread thread = (Thread) iterator.next();
+            for (final Thread thread : threads) {
                 thread.interrupt();
                 thread.join();
             }
-            for (final Iterator iterator = threadGroups.iterator(); iterator.hasNext();) {
-                final ThreadGroup threadGroup = (ThreadGroup) iterator.next();
+            for (final ThreadGroup threadGroup : threadGroups) {
                 if(!threadGroup.isDestroyed())
                 threadGroup.destroy();
             }
         }
     }
     
-    /*public static class PrintVisitor implements Visitor
-    {
-        private int depth = 0;
-
-        @Override
-        public boolean visitEnter(final ThreadGroupHolder threadGroup) {
-            indent();
-            System.out.println("- TG "+threadGroup.getThreadGroup().getName());
-            depth++;
-            return true;
-        }
-
-        @Override
-        public boolean visitLeave(final ThreadGroupHolder threadGroup) {
-            depth--;
-            return true;
-        }
-
-        @Override
-        public boolean visit(final ThreadHolder thread) {
-            indent();
-            System.out.println("- T ["+thread.getThread().getState()+"] " +thread.getThread().getId()+" ("+thread.getThread().getName()+")");
-            return true;
-        }
-
-        private void indent() {
-            System.out.print(StringUtils.repeat(' ', depth));
-        }
-
-    }*/
-
     private static class TestThread extends Thread {
         private final CountDownLatch latch = new CountDownLatch(1);
 


### PR DESCRIPTION
ThreadUtils refactored to use predicates and collectors as the
implementors of Thread and ThreadGroup finder methods.

This is what I was thinking about when I suggested a visitor pattern.

I'm not convinced that these methods are needed or will be used.
